### PR TITLE
Remove homepage field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://atmenterprise.github.io/atm/",
   "scripts": {
     "dev": "vite --port=3000 --host=0.0.0.0",
     "build": "vite build",


### PR DESCRIPTION
Delete the obsolete `homepage` property (https://atmenterprise.github.io/atm/) from package.json. This cleans up unnecessary metadata which can affect build/deployment asset paths.