### PR TITLE
Set Vite base path to /atm/

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import {defineConfig} from 'vite';
 
 export default defineConfig(() => {
   return {
-    base: '/',
+    base: '/atm/',
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: {


### PR DESCRIPTION
Update vite.config.ts to change the build/dev base from '/' to '/atm/' so assets and routes resolve when the app is served from the /atm/ subdirectory (e.g., for subpath deployment).